### PR TITLE
Fix for error alert on appointments page when no appointments

### DIFF
--- a/src/components/dialogs/AddAppointmentDialog.tsx
+++ b/src/components/dialogs/AddAppointmentDialog.tsx
@@ -52,6 +52,9 @@ const AddAppointmentDialog: React.FC<AddAppointmentDialogProps> = ({ open, onClo
             }
             break;
 
+          case 204:
+            break;
+          
           case 400:
             alert("Invalid user ID provided. Please try again.");
             break;


### PR DESCRIPTION
Insert the case for status code 204 when the server returns an empty list